### PR TITLE
Ajout de PHP 7.1

### DIFF
--- a/app/View/Install/first.ctp
+++ b/app/View/Install/first.ctp
@@ -75,7 +75,7 @@
               <td><?= affichImg($compatible['chmod']) ?></td>
             </tr>
             <tr>
-              <td>Version de PHP >= 5.6 < 7.1</td>
+              <td>Version de PHP >= 5.6 < 7.2</td>
               <td><?= affichImg($compatible['phpVersion']) ?></td>
             </tr>
             <tr>

--- a/app/webroot/verif-install.php
+++ b/app/webroot/verif-install.php
@@ -111,7 +111,7 @@ $compatible['openSSL'] = false;
 
 $compatible['curl'] = extension_loaded('cURL');
 
-$compatible['phpVersion'] = version_compare(PHP_VERSION, '5.6', '>=') && version_compare(PHP_VERSION, '7.1', '<');
+$compatible['phpVersion'] = version_compare(PHP_VERSION, '5.6', '>=') && version_compare(PHP_VERSION, '7.2', '<');
 
 $compatible['pdo'] = in_array('pdo_mysql', get_loaded_extensions());
 


### PR DESCRIPTION
PHP 7.0 n'étant plus supporté depuis 4 mois. (Security Support ONLY)
Source : https://secure.php.net/supported-versions.php
