### PR TITLE
Add plugin-shop class, heritage CSS to this class, delete body and footer

### DIFF
--- a/app/webroot/css/shop-homepage.css
+++ b/app/webroot/css/shop-homepage.css
@@ -4,54 +4,53 @@
  * For details, see http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-body {
-    padding-top: 70px; /* Required padding for .navbar-fixed-top. Remove if using .navbar-static-top. Change if height of navigation changes. */
+
+.plugin-shop{
+    padding-top: 70px;
+    padding-bottom: 50px;
 }
 
-.slide-image {
+.plugin-shop .slide-image {
     width: 100%;
 }
 
-.carousel-holder {
+.plugin-shop .carousel-holder {
     margin-bottom: 30px;
 }
 
-.carousel-control,
-.item {
+.plugin-shop .carousel-control,
+.plugin-shop .item {
     border-radius: 4px;
 }
 
-.caption {
+.plugin-shop .caption {
     height: 130px;
     overflow: hidden;
 }
 
-.caption h4 {
+.plugin-shop .caption h4 {
     white-space: nowrap;
 }
 
-.thumbnail img {
+.plugin-shop .thumbnail img {
     width: 100%;
     height: 113px;
     margin: 0 auto;
     display: block;
 }
 
-.ratings {
+.plugin-shop .ratings {
     padding-right: 10px;
     padding-left: 10px;
     color: #d17581;
 }
 
-.thumbnail {
+.plugin-shop .thumbnail {
     padding: 0;
 }
 
-.thumbnail .caption-full {
+.plugin-shop .thumbnail .caption-full {
     padding: 9px;
     color: #333;
 }
 
-footer {
-    margin: 50px 0;
-}


### PR DESCRIPTION
**ATTENTION : A merge uniquement si le plugin Vote a été merge également.**  [(PR ci-présente)](https://github.com/MineWeb/Plugin-Shop/pull/9) 

- La class .plugin-shop a été mise en place comme class parent
- Toutes les class du fichier shop-homepage.css utilise .plugin-shop comme class parent
- Le style du Body et du Footer ont étés supprimés pour être remplacé par un padding sur le container du plugin _(ce qui va faire la même chose mais en plus propre, sauf pour le footer qui avait un margin-bottom également)_

La modification a été testée sur le thème par défaut, cependant merci de faire une review sérieuse de cette modification pour éviter tout problème gênant lors du déploiement. (Regardez pas seulement le code et testez la modif wola)

_____
_PS : Ce serait bien de faire passer la class ".plugin-" comme standard pour le CSS de plugin_