### PR TITLE
improv: Fix deleted columns

### DIFF
--- a/app/Controller/Component/UpdateComponent.php
+++ b/app/Controller/Component/UpdateComponent.php
@@ -198,12 +198,6 @@ class UpdateComponent extends CakeObject
             if (count(explode('-', $column)) > 1) { // Plugin columns are prefixed by `pluginname-<column>`
               unset($diffSchema[$table]['drop'][$column]);
             }
-
-      // If we have columns to drop, we need to check this is not about a plugin
-      if (isset($diffSchema[$table]['drop'])) {
-        foreach ($diffSchema[$table]['drop'] as $column => $structure) { // For each drop, check column name
-          if (count(explode('-', $column)) > 1) { // Plugin columns are prefixed by `pluginname-<column>`
-            unset($diffSchema[$table]['drop'][$column]);
           }
         }
       }

--- a/app/Controller/Component/UpdateComponent.php
+++ b/app/Controller/Component/UpdateComponent.php
@@ -191,8 +191,13 @@ class UpdateComponent extends CakeObject
     foreach ($diffSchema as $table => $changes) {
       if (isset($diffSchema[$table]['create'])) {
         $queries[$table] = $db->createSchema($newSchema, $table);
-        continue;
-      }
+      } else {
+        // If we have columns to drop, we need to check this is not about a plugin
+        if (isset($diffSchema[$table]['drop'])) {
+          foreach ($diffSchema[$table]['drop'] as $column => $structure) { // For each drop, check column name
+            if (count(explode('-', $column)) > 1) { // Plugin columns are prefixed by `pluginname-<column>`
+              unset($diffSchema[$table]['drop'][$column]);
+            }
 
       // If we have columns to drop, we need to check this is not about a plugin
       if (isset($diffSchema[$table]['drop'])) {


### PR DESCRIPTION
Le continue dans cette situation supprime les colonne des plugin qui se situes en dehors de leur propre table, le ELSE régle ce problème:

Pour tester ce correctif il suffit de deux chose, d'avoir un cms vierge de préférence et le plugin forum d'installer au préalable.

1. Après avoir installer le plugin forum rendez vous dans la table 'Users' ou vous pouvez voir la colonne du plugin forum, tout est normal.

2. Ensuite il suffit de mettre à jour le CMS en vidant le cache avant, la colonne du forum a donc disparu, si vous vous déconnectez vous aurez une erreur 500 et impossible de vous reconnecter par la suite.

3. Ensuite il faut refaire apparaître la colonne alors exécutez site.fr/admin/plugin/update/Forum la table réapparaît donc !

4. Maintenant allez dans le fichier app/Controller/Component/UpdateComponent.php et remplacez le par celui du pull, et veillez bien a retirer le changement du fichier UpdateComponent a la ligne environ 122.

5. Ensuite il suffit de mettre à jour le cms et vérifier que la colonne du forum est toujours présente dans la table 'Users'.