### PR TITLE
fix: allows users to get the skin / head

### DIFF
--- a/app/Controller/APIController.php
+++ b/app/Controller/APIController.php
@@ -43,13 +43,13 @@ class APIController extends AppController {
 	}
 
 	public function get_skin($name) {
-		header('Content-Type: image/png');
+		$this->response->type('image/png');
 		$this->autoRender = false;
 		echo $this->API->get_skin($name);
 	}
 
 	public function get_head_skin($name, $size = 50) {
-		header('Content-Type: image/png');
+		$this->response->type('image/png');
 		$this->autoRender = false;
 		echo $this->API->get_head_skin($name, $size);
 	}


### PR DESCRIPTION
Petit fix qui permet aux utilisateurs d'obtenir le skin des utilisateurs enregistrés via mojang avec l'url :
http(s)://lesite.fr/API/get_skin/Lutilisateur

et la tête avec http(s)://lesite.fr/API/get_head_skin/Lutilisateur

On peut également avoir la taille.

(c'est @nivcoo qui a trouvé ce fix)

Screens : 
**Skin**: https://img.hynity.com/images/2019/05/12/chrome_Fj5AB9Zv17.png
**Head**: https://img.hynity.com/images/2019/05/12/chrome_JFy1oVPjQB.png