### PR TITLE
Allowed post requests

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -177,7 +177,7 @@ class AppController extends Controller
     protected function __initSecurity()
     {
         $this->Security->blackHoleCallback = 'blackhole';
-        $this->Security->validatePost = false;
+        $this->Security->validatePost = true;
         $this->Security->csrfUseOnce = false;
 
         $csrfToken = $this->Session->read('_Token')['key'];


### PR DESCRIPTION
J'autorise les requêtes POST pour le plugin auth notamment, mais aussi pour accéder aux routes autorisant le POST plus facilement.
⚠️ Les routes à verrouiller doivent autoriser l'ajax seulement, même si il y en a très peu et qu'elles le sont dejà.

N.B.: Quand je parle du plugin auth, c'est la PR que je vais faire prochainement. 