### PR TITLE
Fixed rank permission deletion

### DIFF
--- a/app/Controller/PermissionsController.php
+++ b/app/Controller/PermissionsController.php
@@ -95,7 +95,7 @@ class PermissionsController extends AppController {
 				$this->Rank->delete($search['Rank']['id']);
 
 				$this->loadModel('Permission');
-				$search_perm = $this->Permission->find('first', array('conditions' => array('id' => $id)));
+				$search_perm = $this->Permission->find('first', array('conditions' => array('rank' => $id)));
 				if(!empty($search_perm)) {
 					$this->Permission->delete($search_perm['Permission']['id']);
 				}


### PR DESCRIPTION
La suppression d'un rang implique la suppression des permissions associées.
La recherche doit se faire sur la colonne `rank` et non `id` de la table `permissions`.

Cette erreur pose plusieurs problèmes:

La recherche ne retourne jamais de résultat, sauf dans le(s) cas suivant(s);
S'il y a 10 rangs, il y a alors 10 permissions. Si le 10e rang est supprimé, la recherche retournera le premier rang créé (`rank` `id = 10`) et supprimera les permission associées.
Idem tous les 10 rangs.

Quand la recherche ne retourne pas de résultat, cela signifie que les permissions ne sont pas supprimées et toujours associées à un ID de rang bien que celui-ci n'existe plus (absence de clés étrangères). Si un utilisateur possédait un rang supprimé, il sera toujours associé à ce rang via son ID, et surtout à ses permissions. L'utilisateur continuera de profiter de ses privilèges.
De plus, l'administrateur ne pourra pas facilement identifier un utilisateur dont le rang a été supprimé, car l'utilisateur en question sera noté comme "Membre". Dans le cas d'une compromission du CMS, cela permet de cacher un utilisateur ayant tous les privilèges au milieu des autres utilisateurs non privilégiés.
