### PR TITLE
improv. auth perf

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -185,18 +185,16 @@ class AppController extends Controller
         if (!$this->User->isConnected() && ($cookie = $this->Cookie->read('remember_me')) && isset($cookie['pseudo']) && isset($cookie['password'])) {
             $user = $this->User->find('first', array('conditions' => array('pseudo' => $cookie['pseudo'])));
 
-            if (!empty($user) && $user['User']['password'] == $cookie['password']) {
+            if (!empty($user) && $user['User']['password'] == $cookie['password'])
                 $this->Session->write('user', $user['User']['id']);
-            }
         }
 
         $this->isConnected = $this->User->isConnected();
         $this->set('isConnected', $this->isConnected);
 
         $user = ($this->isConnected) ? $this->User->getAllFromCurrentUser() : array();
-        if (!empty($user)) {
+        if (!empty($user))
             $user['isAdmin'] = $this->User->isAdmin();
-        }
 
         $this->set(compact('user'));
     }
@@ -360,27 +358,20 @@ class AppController extends Controller
         if (!function_exists('addToNav')) {
             function addToNav($menus, $nav, $index = 0)
             {
-                if (!is_array($menus)) {
+                if (!is_array($menus))
                     return $nav;
-                }
                 foreach ($menus as $name => $menu) {
                     if (isset($nav[$name])) // Multidimensional
-                    {
                         $nav[$name] = addToNav($menu, $nav[$name], $index + 1);
-                    } else { // Add
+                    else { // Add
                         if (!isset($nav['menu']) && $index !== 0) // No others submenu
                         {
                             $nav['menu'] = [];
                         }
                         if ($index === 0) // Add
-                        {
-                            $nav = addToArrayAt($nav, (isset($menu['index']) ? $menu['index'] : count($nav)),
-                                [$name => $menu]);
-                        } else // Add into submenu
-                        {
-                            $nav['menu'] = addToArrayAt($nav['menu'],
-                                (isset($menu['index']) ? $menu['index'] : count($nav['menu'])), [$name => $menu]);
-                        }
+                            $nav = addToArrayAt($nav, (isset($menu['index']) ? $menu['index'] : count($nav)), [$name => $menu]);
+                        else // Add into submenu
+                            $nav['menu'] = addToArrayAt($nav['menu'], (isset($menu['index']) ? $menu['index'] : count($nav['menu'])), [$name => $menu]);
                     }
                 }
                 return $nav;
@@ -403,9 +394,8 @@ class AppController extends Controller
         // Handle plugins
         $plugins = $this->EyPlugin->pluginsLoaded;
         foreach ($plugins as $plugin) {
-            if (!isset($plugin->admin_menus) || !$plugin->active) {
+            if (!isset($plugin->admin_menus) || !$plugin->active)
                 continue;
-            }
             $menus = json_decode(json_encode($plugin->admin_menus), true);
             $nav = addToNav($menus, $nav);
         }
@@ -452,7 +442,7 @@ class AppController extends Controller
         $configuration = $this->Configuration->getKey('banner_server');
         if (empty($configuration) && $this->Server->online())
             $server_infos = $this->Server->banner_infos();
-        else if (!empty($configuration)) {
+        else if (!empty($configuration))
             $server_infos = $this->Server->banner_infos(unserialize($configuration));
         else
             return $this->set(['banner_server' => false, 'server_infos' => false]);

--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -365,9 +365,7 @@ class AppController extends Controller
                         $nav[$name] = addToNav($menu, $nav[$name], $index + 1);
                     else { // Add
                         if (!isset($nav['menu']) && $index !== 0) // No others submenu
-                        {
                             $nav['menu'] = [];
-                        }
                         if ($index === 0) // Add
                             $nav = addToArrayAt($nav, (isset($menu['index']) ? $menu['index'] : count($nav)), [$name => $menu]);
                         else // Add into submenu

--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -36,10 +36,10 @@ require ROOT . '/config/function.php';
 class AppController extends Controller
 {
 
-    var $components = array('Util', 'Module', 'Session', 'Cookie', 'Security', 'EyPlugin', 'Lang', 'Theme', 'History', 'Statistics', 'Permissions', 'Update', 'Server');
-    var $helpers = array('Session');
+    $components = array('Util', 'Module', 'Session', 'Cookie', 'Security', 'EyPlugin', 'Lang', 'Theme', 'History', 'Statistics', 'Permissions', 'Update', 'Server');
+    $helpers = array('Session');
 
-    var $view = 'Theme';
+    $view = 'Theme';
 
     protected $isConnected = false;
 
@@ -65,34 +65,28 @@ class AppController extends Controller
         $this->__initWebsiteInfos();
 
         // Navbar
-        if ($this->params['prefix'] == "admin" && !$this->request->is('ajax')) {
+        if ($this->params['prefix'] == "admin" && !$this->request->is('ajax'))
             $this->__initAdminNavbar();
-        } else {
-            if (!$this->request->is('ajax')) {
-                $this->__initNavbar();
-            }
-        }
+        else if (!$this->request->is('ajax'))
+            $this->__initNavbar();
 
         // Server
-        if ($this->params['prefix'] !== "admin" && !$this->request->is('ajax')) {
+        if ($this->params['prefix'] !== "admin" && !$this->request->is('ajax'))
             $this->__initServerInfos();
-        }
 
         // Plugins events
         $this->EyPlugin->initEventsListeners($this);
 
         $event = new CakeEvent('requestPage', $this, $this->request->data);
         $this->getEventManager()->dispatch($event);
-        if ($event->isStopped()) {
+        if ($event->isStopped())
             return $event->result;
-        }
 
         if ($this->request->is('post')) {
             $event = new CakeEvent('onPostRequest', $this, $this->request->data);
             $this->getEventManager()->dispatch($event);
-            if ($event->isStopped()) {
+            if ($event->isStopped())
                 return $event->result;
-            }
         }
         $LoginCondition = ($this->here != "/login") || !$this->EyPlugin->isInstalled('phpierre.signinup');
         // Maintenance / Bans
@@ -423,35 +417,29 @@ class AppController extends Controller
     {
         $this->loadModel('Navbar');
         $nav = $this->Navbar->find('all', array('order' => 'order'));
-        if (empty($nav)) {
+        if (empty($nav))
             return $this->set('nav', false);
-        }
         $this->loadModel('Page');
         $pages = $this->Page->find('all', array('fields' => array('id', 'slug')));
-        foreach ($pages as $key => $value) {
+        foreach ($pages as $key => $value)
             $pages_listed[$value['Page']['id']] = $value['Page']['slug'];
-        }
         foreach ($nav as $key => $value) {
-            if (!isset($value['Navbar']['url']['type'])) {
+            if (!isset($value['Navbar']['url']['type']))
                 continue;
-            }
             if ($value['Navbar']['url']['type'] == "plugin") {
-                if (isset($value['Navbar']['url']['route'])) {
+                if (isset($value['Navbar']['url']['route']))
                     $plugin = $this->EyPlugin->findPlugin('slug', $value['Navbar']['url']['id']);
-                } else {
+                else
                     $plugin = $this->EyPlugin->findPlugin('DBid', $value['Navbar']['url']['id']);
-                }
-                if (is_object($plugin)) {
+                if (is_object($plugin))
                     $nav[$key]['Navbar']['url'] = (isset($value['Navbar']['url']['route'])) ? Router::url($value['Navbar']['url']['route']) : Router::url('/' . strtolower($plugin->slug));
-                } else {
+                else
                     $nav[$key]['Navbar']['url'] = '#';
-                }
             } elseif ($value['Navbar']['url']['type'] == "page") {
-                if (isset($pages_listed) && isset($pages_listed[$value['Navbar']['url']['id']])) {
+                if (isset($pages_listed) && isset($pages_listed[$value['Navbar']['url']['id']]))
                     $nav[$key]['Navbar']['url'] = Router::url('/p/' . $pages_listed[$value['Navbar']['url']['id']]);
-                } else {
+                else
                     $nav[$key]['Navbar']['url'] = '#';
-                }
             } elseif ($value['Navbar']['url']['type'] == "custom") {
                 $nav[$key]['Navbar']['url'] = $value['Navbar']['url']['url'];
             }
@@ -462,18 +450,14 @@ class AppController extends Controller
     public function __initServerInfos()
     {
         $configuration = $this->Configuration->getKey('banner_server');
-        if (empty($configuration) && $this->Server->online()) {
+        if (empty($configuration) && $this->Server->online())
             $server_infos = $this->Server->banner_infos();
-        } else {
-            if (!empty($configuration)) {
-                $server_infos = $this->Server->banner_infos(unserialize($configuration));
-            } else {
-                return $this->set(['banner_server' => false, 'server_infos' => false]);
-            }
-        }
-        if (!isset($server_infos['GET_MAX_PLAYERS']) || !isset($server_infos['GET_PLAYER_COUNT']) || $server_infos['GET_MAX_PLAYERS'] === 0) {
+        else if (!empty($configuration)) {
+            $server_infos = $this->Server->banner_infos(unserialize($configuration));
+        else
+            return $this->set(['banner_server' => false, 'server_infos' => false]);
+        if (!isset($server_infos['GET_MAX_PLAYERS']) || !isset($server_infos['GET_PLAYER_COUNT']) || $server_infos['GET_MAX_PLAYERS'] === 0)
             return $this->set(['banner_server' => false, 'server_infos' => $server_infos]);
-        }
 
         $this->set([
             'banner_server' => $this->Lang->get('SERVER__STATUS_MESSAGE', array(
@@ -494,8 +478,7 @@ class AppController extends Controller
         $users_count = $this->User->find('count');
         $users_last = $this->User->find('first', array('order' => 'created DESC'));
         $users_last = $users_last['User'];
-        $users_count_today = $this->User->find('count',
-            array('conditions' => array('created LIKE' => date('Y-m-d') . '%')));
+        $users_count_today = $this->User->find('count', array('conditions' => array('created LIKE' => date('Y-m-d') . '%')));
         $visits_count = $this->Visit->getVisitsCount();
         $visits_count_today = $this->Visit->getVisitsByDay(date('Y-m-d'))['count'];
         $admin_dark_mode = $this->Cookie->read('use_admin_dark_mode');
@@ -537,8 +520,7 @@ class AppController extends Controller
         $seo_config['img_url'] = (empty($seo_config['img_url'])) ? $seo_config['favicon_url'] : $seo_config['img_url'];
         $title = $this->viewVars['title_for_layout'];
         $website_name = $this->viewVars['website_name'];
-        $seo_config['title'] = str_replace(["{TITLE}", "{WEBSITE_NAME}"],
-            [($title ? $title : "Error"), ($website_name ? $website_name : "MineWeb")], $seo_config['title']);
+        $seo_config['title'] = str_replace(["{TITLE}", "{WEBSITE_NAME}"], [($title ? $title : "Error"), ($website_name ? $website_name : "MineWeb")], $seo_config['title']);
 
         $this->set(compact('seo_config'));
     }
@@ -556,9 +538,8 @@ class AppController extends Controller
 
     protected function __setTheme()
     {
-        if (!isset($this->params['prefix']) or $this->params['prefix'] !== "admin") {
+        if (!isset($this->params['prefix']) or $this->params['prefix'] !== "admin")
             $this->theme = Configure::read('theme');
-        }
     }
 
     public function blackhole($type)

--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -36,10 +36,10 @@ require ROOT . '/config/function.php';
 class AppController extends Controller
 {
 
-    $components = array('Util', 'Module', 'Session', 'Cookie', 'Security', 'EyPlugin', 'Lang', 'Theme', 'History', 'Statistics', 'Permissions', 'Update', 'Server');
-    $helpers = array('Session');
+    public $components = array('Util', 'Module', 'Session', 'Cookie', 'Security', 'EyPlugin', 'Lang', 'Theme', 'History', 'Statistics', 'Permissions', 'Update', 'Server');
+    public $helpers = array('Session');
 
-    $view = 'Theme';
+    public $view = 'Theme';
 
     protected $isConnected = false;
 

--- a/app/Controller/UserController.php
+++ b/app/Controller/UserController.php
@@ -48,7 +48,7 @@ class UserController extends AppController
                 }
                 // Captcha
                 if ($this->Configuration->getKey('captcha_type') == "2" || $this->Configuration->getKey('captcha_type') == "3") { // ReCaptcha and h-captcha
-                    $validCaptcha = $this->Util->isValidReCaptcha($this->request->data['recaptcha'], $this->Util->getIP(), $this->Configuration->getKey('captcha_google_secret'));
+                    $validCaptcha = $this->Util->isValidReCaptcha($this->request->data['recaptcha'], $this->Util->getIP(), $this->Configuration->getKey('captcha_secret'), $this->Configuration->getKey('captcha_type'));
                 } else {
                     $captcha = $this->Session->read('captcha_code');
                     $validCaptcha = (!empty($captcha) && $captcha == $this->request->data['captcha']);

--- a/app/Controller/UserController.php
+++ b/app/Controller/UserController.php
@@ -129,12 +129,10 @@ class UserController extends AppController
 
     function ajax_login()
     {
-        if (!$this->request->is('post')) {
+        if (!$this->request->is('post'))
             throw new BadRequestException();
-        }
-        if (empty($this->request->data['pseudo']) || empty($this->request->data['password'])) {
+        if (empty($this->request->data['pseudo']) || empty($this->request->data['password']))
             return $this->sendJSON(['statut' => false, 'msg' => $this->Lang->get('ERROR__FILL_ALL_FIELDS')]);
-        }
         $this->autoRender = false;
         $this->response->type('json');
         $this->loadModel('Authentification');
@@ -153,9 +151,8 @@ class UserController extends AppController
 
         $event = new CakeEvent('onLogin', $this, array('user' => $user_login));
         $this->getEventManager()->dispatch($event);
-        if ($event->isStopped()) {
+        if ($event->isStopped())
             return $event->result;
-        }
         if ($infos) {
             $this->Session->write('user_id_two_factor_auth', $user_login['id']);
             $this->sendJSON([
@@ -431,11 +428,9 @@ class UserController extends AppController
             $this->loadModel('Authentification');
             $infos = $this->Authentification->find('first', array('conditions' => array('user_id' => $this->User->getKey('id'), 'enabled' => true)));
             if (empty($infos)) // no two factor auth
-            {
                 $this->set('twoFactorAuthStatus', false);
-            } else {
+            else
                 $this->set('twoFactorAuthStatus', true);
-            }
             $this->loadModel('User');
             $this->set('title_for_layout', $this->User->getKey('pseudo'));
             $this->layout = $this->Configuration->getKey('layout');
@@ -485,25 +480,20 @@ class UserController extends AppController
 
     function resend_confirmation()
     {
-        if (!$this->isConnected && !$this->Session->check('email.confirm.user.id')) {
+        if (!$this->isConnected && !$this->Session->check('email.confirm.user.id'))
             throw new ForbiddenException();
-        }
-        if ($this->isConnected) {
+        if ($this->isConnected)
             $user = $this->User->getAllFromCurrentUser();
-        } else {
+        else
             $user = $this->User->find('first', array('conditions' => array('id' => $this->Session->read('email.confirm.user.id'))));
-        }
         $this->Session->delete('email.confirm.user.id');
-        if (!$user || empty($user)) {
+        if (!$user || empty($user))
             throw new NotFoundException();
-        }
-        if (isset($user['User'])) {
+        if (isset($user['User']))
             $user = $user['User'];
-        }
         $confirmed = $user['confirmed'];
-        if (!$this->Configuration->getKey('confirm_mail_signup') || empty($confirmed) || date('Y-m-d H:i:s', strtotime($confirmed)) == $confirmed) {
+        if (!$this->Configuration->getKey('confirm_mail_signup') || empty($confirmed) || date('Y-m-d H:i:s', strtotime($confirmed)) == $confirmed)
             throw new NotFoundException();
-        }
         $emailMsg = $this->Lang->get('EMAIL__CONTENT_CONFIRM_MAIL', array(
             '{LINK}' => Router::url('/user/confirm/', true) . $confirmed,
             '{IP}' => $this->Util->getIP(),
@@ -515,16 +505,14 @@ class UserController extends AppController
             $this->Lang->get('EMAIL__TITLE_CONFIRM_MAIL'),
             $emailMsg
         )->sendMail();
-        if ($email) {
+        if ($email)
             $this->Session->setFlash($this->Lang->get('USER__CONFIRM_EMAIL_RESEND_SUCCESS'), 'default.success');
-        } else {
+        else
             $this->Session->setFlash($this->Lang->get('USER__CONFIRM_EMAIL_RESEND_FAIL'), 'default.error');
-        }
-        if ($this->isConnected) {
+        if ($this->isConnected)
             $this->redirect(array('action' => 'profile'));
-        } else {
+        else
             $this->redirect('/');
-        }
     }
 
     function change_pw()
@@ -535,8 +523,7 @@ class UserController extends AppController
             if ($this->request->is('ajax')) {
                 if (!empty($this->request->data['password']) and !empty($this->request->data['password_confirmation'])) {
                     $password = $this->Util->password($this->request->data['password'], $this->User->getKey('pseudo'));
-                    $password_confirmation = $this->Util->password($this->request->data['password_confirmation'],
-                        $this->User->getKey('pseudo'), $password);
+                    $password_confirmation = $this->Util->password($this->request->data['password_confirmation'], $this->User->getKey('pseudo'), $password);
                     if ($password == $password_confirmation) {
                         $event = new CakeEvent('beforeUpdatePassword', $this, array('user' => $this->User->getAllFromCurrentUser(), 'new_password' => $password));
                         $this->getEventManager()->dispatch($event);

--- a/app/View/Configuration/admin_index.ctp
+++ b/app/View/Configuration/admin_index.ctp
@@ -105,7 +105,7 @@
                                                 'options' => array(
                                                     'sha256' => 'sha256',
                                                     'sha1' => 'sha1',
-                                                    'sha386' => 'sha386',
+                                                    'sha384' => 'sha384',
                                                     'sha512' => 'sha512',
                                                     'blowfish' => 'bcrypt'
                                                 ),


### PR DESCRIPTION
Bonjour
J'ai amélioré les performances lors de l'inscription des users en enlevant les hash inutiles comme le deuxieme hash a l’inscription et le hash si un utilisateur n'existe pas. J'ai aussi diminué le nombre de requêtes mysql
J'ai tout testé plusieurs fois et tout marche correctement
Je m'excuse pour le formattage comme il est pas consistent sur tout les fichiers et il y a beaucoup de lignes très longues, j'ai pas pu configurer mon éditeur.
J'ai fait ces modifications il y a plusieurs mois pour mon serveur car on avait constaté que cette partie utilisait beaucoup le serveur lors de tests de charges. Comme MineWeb redevient actif je me suis dis que c'est mieux d'en faire profiter tout le monde plutot que de garder ca pour moi et le serveur a fermé alors ca me sert a rien
J'en ai profité pour réparer le sha386 qui n'existe pas et qui fait que tous les mots de passes sont vides quand il est utilisé ce qui est très dangereux car tout le monde peut se login sur tous les comptes !!!!!
Je dev énormément avec symfony mais je ne fais jamais de contribution sur github, si j'ai fait des erreurs dans cette proposition dites moi car je voudrais après faire d'autres améliorations :wink: 
Bonne soirée
