### PR TITLE
improv. fix clear cache before change file

### DIFF
--- a/app/Controller/Component/UpdateComponent.php
+++ b/app/Controller/Component/UpdateComponent.php
@@ -112,11 +112,23 @@ class UpdateComponent extends CakeObject
         }
     }
 
+    private function clearCache()
+    {
+        App::uses('Folder', 'Utility');
+        $folder = new Folder(ROOT . DS . 'app' . DS . 'tmp' . DS . 'cache');
+        if (!empty($folder->path)) {
+            $folder->delete();
+        }
+    }
+
     /**
      * Update CMS files
      */
     public function updateCMS($componentUpdated = false)
     {
+        // Clear cache
+        $this->clearCache();
+
         set_time_limit(0);
         if (!$componentUpdated) {
             // Here, this is the first step of the update. We're trying to keep this component
@@ -183,8 +195,7 @@ class UpdateComponent extends CakeObject
         @unlink(ROOT . DS . 'app' . DS . 'tmp' . DS . $this->lastVersion . '.zip');
 
         // Clear cache
-        Cache::clearGroup(false, '_cake_core_');
-        Cache::clearGroup(false, '_cake_model_');
+        $this->clearCache();
 
         // Update database
         return $this->updateDb();
@@ -284,12 +295,8 @@ class UpdateComponent extends CakeObject
             }
         }
 
-        // Remove cache
-        App::uses('Folder', 'Utility');
-        $folder = new Folder(ROOT . DS . 'app' . DS . 'tmp' . DS . 'cache');
-        if (!empty($folder->path)) {
-            $folder->delete();
-        }
+        // Clear cache
+        $this->clearCache();
 
         // Hook method to update databases data if needed
         $updateEntries = [];


### PR DESCRIPTION
@Eywek tu sais comment regler SQLSTATE[42S22]: Column not found: 1054 Unknown column 'User.allowed_ip' in 'field list' après l'update ? En gros le cache se vide correctement mais après l'update erreur 500 et ca force a vider manuellement le fichier pour que ca marche, j'ai testé de faire comme ce pull avec plusieurs fois la fonction mais ça fait quand même une erreur 500 après l'édit de la bdd