### PR TITLE
Fix navbar permission for server part

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -307,22 +307,27 @@ class AppController extends Controller
                 'menu' => [
                     'SERVER__LINK' => [
                         'icon' => 'fas fa-arrows-alt-h',
+                        'permission' => 'MANAGE_SERVERS',
                         'route' => ['controller' => 'server', 'action' => 'link', 'admin' => true, 'plugin' => false]
                     ],
                     'SERVER__BANLIST' => [
                         'icon' => 'ban',
+                        'permission' => 'MANAGE_SERVERS',
                         'route' => ['controller' => 'server', 'action' => 'banlist', 'admin' => true, 'plugin' => false]
                     ],
                     'SERVER__WHITELIST' => [
                         'icon' => 'list',
+                        'permission' => 'MANAGE_SERVERS',
                         'route' => ['controller' => 'server', 'action' => 'whitelist', 'admin' => true, 'plugin' => false]
                     ],
                     'SERVER__ONLINE_PLAYERS' => [
                         'icon' => 'list-ul',
+                        'permission' => 'MANAGE_SERVERS',
                         'route' => ['controller' => 'server', 'action' => 'online', 'admin' => true, 'plugin' => false]
                     ],
                     'SERVER__CMD' => [
                         'icon' => 'key',
+                        'permission' => 'MANAGE_SERVERS',
                         'route' => ['controller' => 'server', 'action' => 'cmd', 'admin' => true, 'plugin' => false]
                     ]
                 ]


### PR DESCRIPTION
J'ai ajouté la permission : "MANAGER_SERVER" dans la navbar car sinon on voyait la partie server alors qu'on avait pas la perm d'y accèder ;)

(En lien à cette issue : https://github.com/MineWeb/MineWebCMS/issues/223)