### PR TITLE
Remove S for MANAGE_BANS permission and change old name of perm to bypass a ban

### DIFF
--- a/app/Controller/BanController.php
+++ b/app/Controller/BanController.php
@@ -105,7 +105,7 @@ class BanController extends AppController
                     if ($checkIsBan != null)
                         continue;
 
-                    if ($this->Permissions->have($value['User']['rank'], "CAN_BE_BAN"))
+                    if ($this->Permissions->have($value['User']['rank'], "BYPASS_BAN"))
                         continue;
 
                     $username = $value['User']['pseudo'];
@@ -131,7 +131,7 @@ class BanController extends AppController
     {
         $this->autoRender = false;
         $this->response->type('json');
-        if ($this->isConnected and $this->Permissions->can('MANAGE_USERS')) {
+        if ($this->isConnected and $this->Permissions->can('MANAGE_BAN')) {
             $this->loadModel("User");
             if ($query != false) {
                 $result = $this->User->find('all', ['conditions' => ['pseudo LIKE' => $query . '%']]);
@@ -141,7 +141,7 @@ class BanController extends AppController
                     if ($checkIsBan != null)
                         continue;
 
-                    if ($this->Permissions->have($value['User']['rank'], "CAN_BE_BAN"))
+                    if ($this->Permissions->have($value['User']['rank'], "BYPASS_BAN"))
                         continue;
 
                     $users[] = ['pseudo' => $value['User']['pseudo'], 'id' => $value['User']['id']];

--- a/app/Controller/Component/PermissionsComponent.php
+++ b/app/Controller/Component/PermissionsComponent.php
@@ -30,7 +30,7 @@ class PermissionsComponent extends CakeObject
         'VIEW_STATISTICS',
         'MANAGE_THEMES',
         'MANAGE_USERS',
-        'MANAGE_BANS',
+        'MANAGE_BAN',
         'VIEW_WEBSITE_HISTORY'
     ];
 


### PR DESCRIPTION
J'avais mis un S à MANAGE_BANS dans le PermissionsComponent alors que j'en avais pas mis dans les autres parties du code et entre la première version et la version finale de mon code le nom de la permission pour ne pas être banni a changé et j'avais oublié de le changer dans le DataTable pour ban les membres.