### PR TITLE
Fix date 1970 bug in Stats and optimize code

### DIFF
--- a/app/Controller/StatisticsController.php
+++ b/app/Controller/StatisticsController.php
@@ -35,17 +35,10 @@ class StatisticsController extends AppController
 
             if ($visits) {
                 foreach ($visits as $key => $value) {
+                    $oldDate = strtotime($key);
+                    $newDate = $oldDate * 1000;
 
-                    $date = strtotime($key);
-                    $date = $date * 1000;
-
-                    $visitsToFormatte[$date] = intval($value);
-
-                }
-
-                $i = 0;
-                foreach ($visitsToFormatte as $key => $value) {
-                    $visitsFormatted[] = [$key, $value];
+                    $visitsFormatted[] = [$newDate, intval($value)];
                 }
 
                 $this->response->body(json_encode($visitsFormatted));


### PR DESCRIPTION
Chez certaines personnes le datetime * 1000 ne se mettait pas dans l'ancien premier tableau, il mettait la valeur sans le * 1000. J'ai du coup enlevé la 1ère boucle for qui ne servait à rien sachant que ce qu'elle faisait pouvait être mis dans la 2ème boucle