### PR TITLE
Fix form data

### DIFF
--- a/app/Controller/PermissionsController.php
+++ b/app/Controller/PermissionsController.php
@@ -20,6 +20,9 @@ class PermissionsController extends AppController
         if ($this->request->is('post')) {
             $permissions = [];
             foreach ($this->request->data as $permission => $checked) {
+                if ($checked != "on")
+                    continue;
+                
                 list($permission, $rank) = explode('-', $permission);
                 $permissions[$rank][] = $permission;
             }

--- a/app/Controller/PermissionsController.php
+++ b/app/Controller/PermissionsController.php
@@ -20,7 +20,7 @@ class PermissionsController extends AppController
         if ($this->request->is('post')) {
             $permissions = [];
             foreach ($this->request->data as $permission => $checked) {
-                if ($checked != "on")
+                if(is_array($checked))
                     continue;
                 
                 list($permission, $rank) = explode('-', $permission);


### PR DESCRIPTION
Le _Token et le xss du formulaire étaient détéctés dans la boucle d'initialisation rank/permissions donc il ajoutait dans le tableau une clé vide ('') pour ces deux champs.