### PR TITLE
Add link between TinyMCE dark mode and admin dark mode

### DIFF
--- a/app/View/Layouts/admin.ctp
+++ b/app/View/Layouts/admin.ctp
@@ -57,11 +57,18 @@
                     if (btn.is(':checked')) {
                         $('body').addClass("dark-mode");
                     } else {
-
                         $('body').removeClass("dark-mode");
                     }
 
                     $.get('<?= $this->Html->url(['action' => 'switchAdminDarkMode', 'controller' => 'admin', 'admin' => true]) ?>');
+
+                    // Update TinyMCE
+                    if ($("#editor").length) {
+                        tinymce.remove("#editor");
+                        tinyParams.skin = btn.is(":checked") ? 'oxide-dark' : "";
+                        tinyParams.content_css = btn.is(":checked") ? "dark" : "";
+                        tinymce.init(tinyParams);
+                    }
 
                     return false;
                 });

--- a/app/View/Layouts/admin.ctp
+++ b/app/View/Layouts/admin.ctp
@@ -225,6 +225,23 @@
             <?php echo $this->Session->flash(); ?>
         </section>
 
+        <script type="text/javascript">
+            let tinyParams = {
+                selector: "textarea",
+                height: 300,
+                width: '100%',
+                language: 'fr_FR',
+                plugins: "code image link",
+                toolbar: "fontselect fontsizeselect bold italic underline strikethrough link image forecolor backcolor alignleft aligncenter alignright alignjustify cut copy paste bullist numlist outdent indent blockquote code"
+            };
+            <?php
+            if ($admin_dark_mode) { ?>
+            tinyParams.skin = 'oxide-dark';
+            tinyParams.content_css = "dark";
+            <?php }
+            ?>
+        </script>
+
         <?php echo $this->fetch('content'); ?>
     </div>
 

--- a/app/View/Maintenance/admin_add.ctp
+++ b/app/View/Maintenance/admin_add.ctp
@@ -19,14 +19,23 @@
                             <label><?= $Lang->get('MAINTENANCE__REASON') ?></label>
                             <?= $this->Html->script('admin/tinymce/tinymce.min.js') ?>
                             <script type="text/javascript">
-                                tinymce.init({
+                                let tinyParams = {
                                     selector: "textarea",
                                     height: 300,
                                     width: '100%',
                                     language: 'fr_FR',
-                                    plugins: "textcolor code image link",
+                                    plugins: "code image link",
                                     toolbar: "fontselect fontsizeselect bold italic underline strikethrough link image forecolor backcolor alignleft aligncenter alignright alignjustify cut copy paste bullist numlist outdent indent blockquote code"
-                                });
+                                };
+
+                                <?php
+                                if ($admin_dark_mode) { ?>
+                                    tinyParams.skin = 'oxide-dark';
+                                    tinyParams.content_css = "dark";
+                                <?php }
+                                ?>
+
+                                tinymce.init(tinyParams);
                             </script>
                             <textarea id="editor" name="reason" cols="30"
                                       rows="10"></textarea>

--- a/app/View/Maintenance/admin_add.ctp
+++ b/app/View/Maintenance/admin_add.ctp
@@ -19,22 +19,6 @@
                             <label><?= $Lang->get('MAINTENANCE__REASON') ?></label>
                             <?= $this->Html->script('admin/tinymce/tinymce.min.js') ?>
                             <script type="text/javascript">
-                                let tinyParams = {
-                                    selector: "textarea",
-                                    height: 300,
-                                    width: '100%',
-                                    language: 'fr_FR',
-                                    plugins: "code image link",
-                                    toolbar: "fontselect fontsizeselect bold italic underline strikethrough link image forecolor backcolor alignleft aligncenter alignright alignjustify cut copy paste bullist numlist outdent indent blockquote code"
-                                };
-
-                                <?php
-                                if ($admin_dark_mode) { ?>
-                                    tinyParams.skin = 'oxide-dark';
-                                    tinyParams.content_css = "dark";
-                                <?php }
-                                ?>
-
                                 tinymce.init(tinyParams);
                             </script>
                             <textarea id="editor" name="reason" cols="30"

--- a/app/View/Maintenance/admin_edit.ctp
+++ b/app/View/Maintenance/admin_edit.ctp
@@ -19,14 +19,23 @@
                             <label><?= $Lang->get('MAINTENANCE__REASON') ?></label>
                             <?= $this->Html->script('admin/tinymce/tinymce.min.js') ?>
                             <script type="text/javascript">
-                                tinymce.init({
+                                let tinyParams = {
                                     selector: "textarea",
                                     height: 300,
                                     width: '100%',
                                     language: 'fr_FR',
-                                    plugins: "textcolor code image link",
+                                    plugins: "code image link",
                                     toolbar: "fontselect fontsizeselect bold italic underline strikethrough link image forecolor backcolor alignleft aligncenter alignright alignjustify cut copy paste bullist numlist outdent indent blockquote code"
-                                });
+                                };
+
+                                <?php
+                                if ($admin_dark_mode) { ?>
+                                    tinyParams.skin = 'oxide-dark';
+                                    tinyParams.content_css = "dark";
+                                <?php }
+                                ?>
+
+                                tinymce.init(tinyParams);
                             </script>
                             <textarea id="editor" name="reason" cols="30" rows="10"><?= $page["reason"] ?></textarea>
                         </div>

--- a/app/View/Maintenance/admin_edit.ctp
+++ b/app/View/Maintenance/admin_edit.ctp
@@ -19,22 +19,6 @@
                             <label><?= $Lang->get('MAINTENANCE__REASON') ?></label>
                             <?= $this->Html->script('admin/tinymce/tinymce.min.js') ?>
                             <script type="text/javascript">
-                                let tinyParams = {
-                                    selector: "textarea",
-                                    height: 300,
-                                    width: '100%',
-                                    language: 'fr_FR',
-                                    plugins: "code image link",
-                                    toolbar: "fontselect fontsizeselect bold italic underline strikethrough link image forecolor backcolor alignleft aligncenter alignright alignjustify cut copy paste bullist numlist outdent indent blockquote code"
-                                };
-
-                                <?php
-                                if ($admin_dark_mode) { ?>
-                                    tinyParams.skin = 'oxide-dark';
-                                    tinyParams.content_css = "dark";
-                                <?php }
-                                ?>
-
                                 tinymce.init(tinyParams);
                             </script>
                             <textarea id="editor" name="reason" cols="30" rows="10"><?= $page["reason"] ?></textarea>

--- a/app/View/News/admin_add.ctp
+++ b/app/View/News/admin_add.ctp
@@ -36,14 +36,23 @@
                         <div class="form-group">
                             <?= $this->Html->script('admin/tinymce/tinymce.min.js') ?>
                             <script type="text/javascript">
-                                tinymce.init({
+                                let tinyParams = {
                                     selector: "textarea",
                                     height: 300,
                                     width: '100%',
                                     language: 'fr_FR',
-                                    plugins: "textcolor code image link",
+                                    plugins: "code image link",
                                     toolbar: "fontselect fontsizeselect bold italic underline strikethrough link image forecolor backcolor alignleft aligncenter alignright alignjustify cut copy paste bullist numlist outdent indent blockquote code"
-                                });
+                                };
+
+                                <?php
+                                    if ($admin_dark_mode) { ?>
+                                        tinyParams.skin = 'oxide-dark';
+                                        tinyParams.content_css = "dark";
+                                    <?php }
+                                 ?>
+
+                                tinymce.init(tinyParams);
                             </script>
                             <textarea id="editor" name="content" cols="30" rows="10"></textarea>
                         </div>

--- a/app/View/News/admin_add.ctp
+++ b/app/View/News/admin_add.ctp
@@ -36,22 +36,6 @@
                         <div class="form-group">
                             <?= $this->Html->script('admin/tinymce/tinymce.min.js') ?>
                             <script type="text/javascript">
-                                let tinyParams = {
-                                    selector: "textarea",
-                                    height: 300,
-                                    width: '100%',
-                                    language: 'fr_FR',
-                                    plugins: "code image link",
-                                    toolbar: "fontselect fontsizeselect bold italic underline strikethrough link image forecolor backcolor alignleft aligncenter alignright alignjustify cut copy paste bullist numlist outdent indent blockquote code"
-                                };
-
-                                <?php
-                                    if ($admin_dark_mode) { ?>
-                                        tinyParams.skin = 'oxide-dark';
-                                        tinyParams.content_css = "dark";
-                                    <?php }
-                                 ?>
-
                                 tinymce.init(tinyParams);
                             </script>
                             <textarea id="editor" name="content" cols="30" rows="10"></textarea>

--- a/app/View/News/admin_edit.ctp
+++ b/app/View/News/admin_edit.ctp
@@ -39,14 +39,23 @@
                         <div class="form-group">
                             <?= $this->Html->script('admin/tinymce/tinymce.min.js') ?>
                             <script type="text/javascript">
-                                tinymce.init({
+                                let tinyParams = {
                                     selector: "textarea",
                                     height: 300,
                                     width: '100%',
                                     language: 'fr_FR',
-                                    plugins: "textcolor code image link",
+                                    plugins: "code image link",
                                     toolbar: "fontselect fontsizeselect bold italic underline strikethrough link image forecolor backcolor alignleft aligncenter alignright alignjustify cut copy paste bullist numlist outdent indent blockquote code"
-                                });
+                                };
+
+                                <?php
+                                if ($admin_dark_mode) { ?>
+                                    tinyParams.skin = 'oxide-dark';
+                                    tinyParams.content_css = "dark";
+                                <?php }
+                                ?>
+
+                                tinymce.init(tinyParams);
                             </script>
                             <textarea id="editor" name="content" cols="30" rows="10"><?= $news['content'] ?></textarea>
                         </div>

--- a/app/View/News/admin_edit.ctp
+++ b/app/View/News/admin_edit.ctp
@@ -39,22 +39,6 @@
                         <div class="form-group">
                             <?= $this->Html->script('admin/tinymce/tinymce.min.js') ?>
                             <script type="text/javascript">
-                                let tinyParams = {
-                                    selector: "textarea",
-                                    height: 300,
-                                    width: '100%',
-                                    language: 'fr_FR',
-                                    plugins: "code image link",
-                                    toolbar: "fontselect fontsizeselect bold italic underline strikethrough link image forecolor backcolor alignleft aligncenter alignright alignjustify cut copy paste bullist numlist outdent indent blockquote code"
-                                };
-
-                                <?php
-                                if ($admin_dark_mode) { ?>
-                                    tinyParams.skin = 'oxide-dark';
-                                    tinyParams.content_css = "dark";
-                                <?php }
-                                ?>
-
                                 tinymce.init(tinyParams);
                             </script>
                             <textarea id="editor" name="content" cols="30" rows="10"><?= $news['content'] ?></textarea>

--- a/app/View/Pages/admin_add.ctp
+++ b/app/View/Pages/admin_add.ctp
@@ -36,22 +36,6 @@
                         <div class="form-group">
                             <?= $this->Html->script('admin/tinymce/tinymce.min.js') ?>
                             <script type="text/javascript">
-                                let tinyParams = {
-                                    selector: "textarea",
-                                    height: 300,
-                                    width: '100%',
-                                    language: 'fr_FR',
-                                    plugins: "code image link",
-                                    toolbar: "fontselect fontsizeselect bold italic underline strikethrough link image forecolor backcolor alignleft aligncenter alignright alignjustify cut copy paste bullist numlist outdent indent blockquote code"
-                                };
-
-                                <?php
-                                if ($admin_dark_mode) { ?>
-                                    tinyParams.skin = 'oxide-dark';
-                                    tinyParams.content_css = "dark";
-                                <?php }
-                                ?>
-
                                 tinymce.init(tinyParams);
                             </script>
                             <textarea id="editor" name="content" cols="30" rows="10"></textarea>

--- a/app/View/Pages/admin_add.ctp
+++ b/app/View/Pages/admin_add.ctp
@@ -36,14 +36,23 @@
                         <div class="form-group">
                             <?= $this->Html->script('admin/tinymce/tinymce.min.js') ?>
                             <script type="text/javascript">
-                                tinymce.init({
+                                let tinyParams = {
                                     selector: "textarea",
                                     height: 300,
                                     width: '100%',
                                     language: 'fr_FR',
-                                    plugins: "textcolor code image link",
-                                    toolbar: "fontselect fontsizeselect bold italic underline strikethrough image link forecolor backcolor alignleft aligncenter alignright alignjustify cut copy paste bullist numlist outdent indent blockquote code"
-                                });
+                                    plugins: "code image link",
+                                    toolbar: "fontselect fontsizeselect bold italic underline strikethrough link image forecolor backcolor alignleft aligncenter alignright alignjustify cut copy paste bullist numlist outdent indent blockquote code"
+                                };
+
+                                <?php
+                                if ($admin_dark_mode) { ?>
+                                    tinyParams.skin = 'oxide-dark';
+                                    tinyParams.content_css = "dark";
+                                <?php }
+                                ?>
+
+                                tinymce.init(tinyParams);
                             </script>
                             <textarea id="editor" name="content" cols="30" rows="10"></textarea>
                         </div>

--- a/app/View/Pages/admin_edit.ctp
+++ b/app/View/Pages/admin_edit.ctp
@@ -38,14 +38,23 @@
                         <div class="form-group">
                             <?= $this->Html->script('admin/tinymce/tinymce.min.js') ?>
                             <script type="text/javascript">
-                                tinymce.init({
+                                let tinyParams = {
                                     selector: "textarea",
                                     height: 300,
                                     width: '100%',
                                     language: 'fr_FR',
-                                    plugins: "textcolor code image link",
+                                    plugins: "code image link",
                                     toolbar: "fontselect fontsizeselect bold italic underline strikethrough link image forecolor backcolor alignleft aligncenter alignright alignjustify cut copy paste bullist numlist outdent indent blockquote code"
-                                });
+                                };
+
+                                <?php
+                                if ($admin_dark_mode) { ?>
+                                    tinyParams.skin = 'oxide-dark';
+                                    tinyParams.content_css = "dark";
+                                <?php }
+                                ?>
+
+                                tinymce.init(tinyParams);
                             </script>
                             <textarea id="editor" name="content" cols="30" rows="10"><?= $page['content'] ?></textarea>
                         </div>

--- a/app/View/Pages/admin_edit.ctp
+++ b/app/View/Pages/admin_edit.ctp
@@ -38,22 +38,6 @@
                         <div class="form-group">
                             <?= $this->Html->script('admin/tinymce/tinymce.min.js') ?>
                             <script type="text/javascript">
-                                let tinyParams = {
-                                    selector: "textarea",
-                                    height: 300,
-                                    width: '100%',
-                                    language: 'fr_FR',
-                                    plugins: "code image link",
-                                    toolbar: "fontselect fontsizeselect bold italic underline strikethrough link image forecolor backcolor alignleft aligncenter alignright alignjustify cut copy paste bullist numlist outdent indent blockquote code"
-                                };
-
-                                <?php
-                                if ($admin_dark_mode) { ?>
-                                    tinyParams.skin = 'oxide-dark';
-                                    tinyParams.content_css = "dark";
-                                <?php }
-                                ?>
-
                                 tinymce.init(tinyParams);
                             </script>
                             <textarea id="editor" name="content" cols="30" rows="10"><?= $page['content'] ?></textarea>


### PR DESCRIPTION
J'ai ajouté un système permettant de passer TinyMCE en Light/Dark dépendant des paramètres du panel admin et j'ai enlevé le plugin "TextColor" qui est intégré par défaut dans la version de TinyMCE présente sur le CMS (il y avait un warning dans la console)